### PR TITLE
Consider leading zeros as significant part of data

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -72,7 +72,6 @@ function generate(){
             "directionals",
             "ampersand",
             "remove_ordinals",
-            "removeAllZeroNumericPrefix",
             "peliasOneEdgeGramFilter",
             "unique_only_same_position",
             "notnull",
@@ -88,7 +87,6 @@ function generate(){
             "lowercase",
             "trim",
             "remove_ordinals",
-            "removeAllZeroNumericPrefix",
             "unique_only_same_position",
             "notnull"
           ]


### PR DESCRIPTION
Otherwise searching stop code such as 0001 is hopeless, because so many items
include plain digit 1.